### PR TITLE
Prevent too many requests being sent.

### DIFF
--- a/Jellyfin.Plugin.OpenSubtitles/Jellyfin.Plugin.OpenSubtitles.csproj
+++ b/Jellyfin.Plugin.OpenSubtitles/Jellyfin.Plugin.OpenSubtitles.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.OpenSubtitles</RootNamespace>
-    <AssemblyVersion>5.0.0</AssemblyVersion>
-    <FileVersion>5.0.0</FileVersion>
+    <AssemblyVersion>6.0.0</AssemblyVersion>
+    <FileVersion>6.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-opensubtitles"
 guid: "4b9ed42f-5185-48b5-9803-6ff2989014c4"
-version: "5" # Please increment with each pull request
+version: "6" # Please increment with each pull request
 jellyfin_version: "10.3.7" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Open Subtitles"


### PR DESCRIPTION
**Changes**
Getting the rate limit remaining from the supplied header value from opensubtitles.org. Using this to prevent code from sending too many requests and missing many subtitles. Updating version numbers. Renaming variable.

**Issues**
Fixes #10
