### PR TITLE
Fixes, language improvements, code cleanup & error logging

### DIFF
--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
@@ -104,9 +104,9 @@ namespace Jellyfin.Plugin.OpenSubtitles
                     hash = OpenSubtitlesRequestHelper.ComputeHash(fileStream);
                 }
             }
-            catch (IOException e)
+            catch (IOException ex)
             {
-                throw new IOException(string.Format(CultureInfo.InvariantCulture, "IOException while computing hash for {0}", request.MediaPath), e);
+                throw new IOException(string.Format(CultureInfo.InvariantCulture, "IOException while computing hash for {0}", request.MediaPath), ex);
             }
 
             var options = new Dictionary<string, string>

--- a/OpenSubtitlesHandler/Models/ApiResponse.cs
+++ b/OpenSubtitlesHandler/Models/ApiResponse.cs
@@ -24,12 +24,17 @@ namespace OpenSubtitlesHandler.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse{T}"/> class.
         /// </summary>
-        /// <param name="response">The response string.</param>
-        /// <param name="statusCode">The status code.</param>
-        public ApiResponse(string response, HttpStatusCode statusCode)
+        /// <param name="response">The http response.</param>
+        /// <param name="context">The request context.</param>
+        public ApiResponse(HttpResponse response, params string[] context)
         {
-            Code = statusCode;
-            Body = response;
+            Code = response.Code;
+            Body = response.Body;
+
+            if (!Ok && string.IsNullOrWhiteSpace(Body) && !string.IsNullOrWhiteSpace(response.Reason))
+            {
+                Body = response.Reason;
+            }
 
             if (typeof(T) == typeof(string))
             {
@@ -49,7 +54,7 @@ namespace OpenSubtitlesHandler.Models
             }
             catch (Exception ex)
             {
-                throw new JsonException($"Failed to parse JSON: \n{(string.IsNullOrWhiteSpace(Body) ? @"""" : Body)}", ex);
+                throw new JsonException($"Failed to parse response, code: {Code}, context: {context}, body: \n{(string.IsNullOrWhiteSpace(Body) ? @"""" : Body)}", ex);
             }
         }
 

--- a/OpenSubtitlesHandler/Models/ApiResponse.cs
+++ b/OpenSubtitlesHandler/Models/ApiResponse.cs
@@ -13,12 +13,18 @@ namespace OpenSubtitlesHandler.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse{T}"/> class.
         /// </summary>
-        /// <param name="response">The response.</param>
-        /// <param name="statusCode">The status code.</param>
-        public ApiResponse(T response, HttpStatusCode statusCode)
+        /// <param name="data">The data.</param>
+        /// <param name="response">The http response.</param>
+        public ApiResponse(T data, HttpResponse response)
         {
-            Code = statusCode;
-            Data = response;
+            Data = data;
+            Code = response.Code;
+            Body = response.Body;
+
+            if (!Ok && string.IsNullOrWhiteSpace(Body) && !string.IsNullOrWhiteSpace(response.Reason))
+            {
+                Body = response.Reason;
+            }
         }
 
         /// <summary>

--- a/OpenSubtitlesHandler/Models/ApiResponse.cs
+++ b/OpenSubtitlesHandler/Models/ApiResponse.cs
@@ -60,7 +60,7 @@ namespace OpenSubtitlesHandler.Models
             }
             catch (Exception ex)
             {
-                throw new JsonException($"Failed to parse response, code: {Code}, context: {context}, body: \n{(string.IsNullOrWhiteSpace(Body) ? @"""" : Body)}", ex);
+                throw new JsonException($"Failed to parse response, code: {Code}, context: {context}, body: \n{(string.IsNullOrWhiteSpace(Body) ? "\"\"" : Body)}", ex);
             }
         }
 

--- a/OpenSubtitlesHandler/Models/ApiResponse.cs
+++ b/OpenSubtitlesHandler/Models/ApiResponse.cs
@@ -47,9 +47,9 @@ namespace OpenSubtitlesHandler.Models
             {
                 Data = JsonSerializer.Deserialize<T>(Body) ?? default;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new JsonException($"Failed to parse JSON: \n{Body}", e);
+                throw new JsonException($"Failed to parse JSON: \n{(string.IsNullOrWhiteSpace(Body) ? @"""" : Body)}", ex);
             }
         }
 

--- a/OpenSubtitlesHandler/Models/HttpResponse.cs
+++ b/OpenSubtitlesHandler/Models/HttpResponse.cs
@@ -1,0 +1,32 @@
+using System.Net;
+
+namespace OpenSubtitlesHandler.Models
+{
+    /// <summary>
+    /// The http response.
+    /// </summary>
+    public class HttpResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpResponse"/> class.
+        /// </summary>
+        public HttpResponse()
+        {
+        }
+
+        /// <summary>
+        /// Gets the status code.
+        /// </summary>
+        public HttpStatusCode Code { get; init; }
+
+        /// <summary>
+        /// Gets the response body.
+        /// </summary>
+        public string Body { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets the response fail reason.
+        /// </summary>
+        public string Reason { get; init; } = string.Empty;
+    }
+}

--- a/OpenSubtitlesHandler/Models/Responses/EncapsulatedLanguageList.cs
+++ b/OpenSubtitlesHandler/Models/Responses/EncapsulatedLanguageList.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace OpenSubtitlesHandler.Models.Responses
+{
+    /// <summary>
+    /// The encapsulated language list.
+    /// </summary>
+    public class EncapsulatedLanguageList
+    {
+        /// <summary>
+        /// Gets or sets the language list.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public IReadOnlyList<LanguageInfo>? Data { get; set; }
+    }
+}

--- a/OpenSubtitlesHandler/Models/Responses/LanguageInfo.cs
+++ b/OpenSubtitlesHandler/Models/Responses/LanguageInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace OpenSubtitlesHandler.Models.Responses
+{
+    /// <summary>
+    /// The language info.
+    /// </summary>
+    public class LanguageInfo
+    {
+        /// <summary>
+        /// Gets or sets the language code.
+        /// </summary>
+        [JsonPropertyName("language_code")]
+        public string? Code { get; set; }
+    }
+}

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -126,7 +126,7 @@ namespace OpenSubtitlesHandler
             }
 
             var max = -1;
-            var current = 0;
+            var current = 1;
 
             List<ResponseData> final = new ();
             ApiResponse<SearchResult> last;
@@ -161,6 +161,19 @@ namespace OpenSubtitlesHandler
             while (current < max && last.Data.Data.Count == 100);
 
             return new ApiResponse<IReadOnlyList<ResponseData>>(final, last.Code);
+        }
+
+        /// <summary>
+        /// Get language list.
+        /// </summary>
+        /// <param name="apiKey">The api key.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The list of languages.</returns>
+        public static async Task<ApiResponse<EncapsulatedLanguageList>> GetLanguageList(string apiKey, CancellationToken cancellationToken)
+        {
+            var response = await RequestHandler.SendRequestAsync("/infos/languages", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);
+
+            return new ApiResponse<EncapsulatedLanguageList>(response);
         }
     }
 }

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -28,7 +28,14 @@ namespace OpenSubtitlesHandler
             var body = new { username, password };
             var response = await RequestHandler.SendRequestAsync("/login", HttpMethod.Post, body, null, apiKey, cancellationToken).ConfigureAwait(false);
 
-            return new ApiResponse<LoginInfo>(response.Response, response.StatusCode);
+            try
+            {
+                return new ApiResponse<LoginInfo>(response.Response, response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                throw new HttpRequestException($"Failed to log in, code: {response.StatusCode}", ex);
+            }
         }
 
         /// <summary>
@@ -49,7 +56,14 @@ namespace OpenSubtitlesHandler
 
             var response = await RequestHandler.SendRequestAsync("/logout", HttpMethod.Delete, null, headers, apiKey, cancellationToken).ConfigureAwait(false);
 
-            return new ApiResponse<object>(response.Response, response.StatusCode).Ok;
+            try
+            {
+                return new ApiResponse<object>(response.Response, response.StatusCode).Ok;
+            }
+            catch (Exception ex)
+            {
+                throw new HttpRequestException($"Failed to log out, code: {response.StatusCode}", ex);
+            }
         }
 
         /// <summary>
@@ -70,7 +84,14 @@ namespace OpenSubtitlesHandler
 
             var response = await RequestHandler.SendRequestAsync("/infos/user", HttpMethod.Get, null, headers, apiKey, cancellationToken).ConfigureAwait(false);
 
-            return new ApiResponse<EncapsulatedUserInfo>(response.Response, response.StatusCode);
+            try
+            {
+                return new ApiResponse<EncapsulatedUserInfo>(response.Response, response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                throw new HttpRequestException($"Failed to obtain user info, code: {response.StatusCode}", ex);
+            }
         }
 
         /// <summary>
@@ -93,7 +114,14 @@ namespace OpenSubtitlesHandler
             var body = new { file_id = file };
             var response = await RequestHandler.SendRequestAsync("/download", HttpMethod.Post, body, headers, apiKey, cancellationToken).ConfigureAwait(false);
 
-            return new ApiResponse<SubtitleDownloadInfo>(response.Response, response.StatusCode);
+            try
+            {
+                return new ApiResponse<SubtitleDownloadInfo>(response.Response, response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                throw new HttpRequestException($"Failed to obtain subtitle link for file {file}, code: {response.StatusCode}", ex);
+            }
         }
 
         /// <summary>
@@ -137,7 +165,14 @@ namespace OpenSubtitlesHandler
 
                 var response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);
 
-                last = new ApiResponse<SearchResult>(response.Response, response.StatusCode);
+                try
+                {
+                    last = new ApiResponse<SearchResult>(response.Response, response.StatusCode);
+                }
+                catch (Exception ex)
+                {
+                    throw new HttpRequestException($"Failed to search for subtitles, options: {opts}, code: {response.StatusCode}", ex);
+                }
 
                 if (!last.Ok || last.Data == null)
                 {

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -130,12 +130,13 @@ namespace OpenSubtitlesHandler
 
             List<ResponseData> final = new ();
             ApiResponse<SearchResult> last;
+            HttpResponse response;
 
             do
             {
                 opts.Set("page", current.ToString(CultureInfo.InvariantCulture));
 
-                var response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);
+                response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);
 
                 last = new ApiResponse<SearchResult>(response, $"options: {options}", $"page: {current}");
 
@@ -146,7 +147,7 @@ namespace OpenSubtitlesHandler
 
                 if (last.Data.TotalPages == 0)
                 {
-                    return new ApiResponse<IReadOnlyList<ResponseData>>(final, response.Code);
+                    break;
                 }
 
                 if (max == -1)
@@ -158,9 +159,9 @@ namespace OpenSubtitlesHandler
 
                 final.AddRange(last.Data.Data);
             }
-            while (current < max && last.Data.Data.Count == 100);
+            while (current <= max && last.Data.Data.Count == 100);
 
-            return new ApiResponse<IReadOnlyList<ResponseData>>(final, last.Code);
+            return new ApiResponse<IReadOnlyList<ResponseData>>(final, response);
         }
 
         /// <summary>

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -28,14 +28,7 @@ namespace OpenSubtitlesHandler
             var body = new { username, password };
             var response = await RequestHandler.SendRequestAsync("/login", HttpMethod.Post, body, null, apiKey, cancellationToken).ConfigureAwait(false);
 
-            try
-            {
-                return new ApiResponse<LoginInfo>(response.Response, response.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                throw new HttpRequestException($"Failed to log in, code: {response.StatusCode}", ex);
-            }
+            return new ApiResponse<LoginInfo>(response);
         }
 
         /// <summary>
@@ -56,14 +49,7 @@ namespace OpenSubtitlesHandler
 
             var response = await RequestHandler.SendRequestAsync("/logout", HttpMethod.Delete, null, headers, apiKey, cancellationToken).ConfigureAwait(false);
 
-            try
-            {
-                return new ApiResponse<object>(response.Response, response.StatusCode).Ok;
-            }
-            catch (Exception ex)
-            {
-                throw new HttpRequestException($"Failed to log out, code: {response.StatusCode}", ex);
-            }
+            return new ApiResponse<object>(response).Ok;
         }
 
         /// <summary>
@@ -84,14 +70,7 @@ namespace OpenSubtitlesHandler
 
             var response = await RequestHandler.SendRequestAsync("/infos/user", HttpMethod.Get, null, headers, apiKey, cancellationToken).ConfigureAwait(false);
 
-            try
-            {
-                return new ApiResponse<EncapsulatedUserInfo>(response.Response, response.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                throw new HttpRequestException($"Failed to obtain user info, code: {response.StatusCode}", ex);
-            }
+            return new ApiResponse<EncapsulatedUserInfo>(response);
         }
 
         /// <summary>
@@ -114,14 +93,7 @@ namespace OpenSubtitlesHandler
             var body = new { file_id = file };
             var response = await RequestHandler.SendRequestAsync("/download", HttpMethod.Post, body, headers, apiKey, cancellationToken).ConfigureAwait(false);
 
-            try
-            {
-                return new ApiResponse<SubtitleDownloadInfo>(response.Response, response.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                throw new HttpRequestException($"Failed to obtain subtitle link for file {file}, code: {response.StatusCode}", ex);
-            }
+            return new ApiResponse<SubtitleDownloadInfo>(response, $"file id: {file}");
         }
 
         /// <summary>
@@ -134,7 +106,7 @@ namespace OpenSubtitlesHandler
         {
             var response = await RequestHandler.SendRequestAsync(url, HttpMethod.Get, null, null, null, cancellationToken).ConfigureAwait(false);
 
-            return new ApiResponse<string>(response.Response, response.StatusCode);
+            return new ApiResponse<string>(response);
         }
 
         /// <summary>
@@ -165,14 +137,7 @@ namespace OpenSubtitlesHandler
 
                 var response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);
 
-                try
-                {
-                    last = new ApiResponse<SearchResult>(response.Response, response.StatusCode);
-                }
-                catch (Exception ex)
-                {
-                    throw new HttpRequestException($"Failed to search for subtitles, options: {opts}, code: {response.StatusCode}", ex);
-                }
+                last = new ApiResponse<SearchResult>(response, $"options: {options}", $"page: {current}");
 
                 if (!last.Ok || last.Data == null)
                 {
@@ -181,7 +146,7 @@ namespace OpenSubtitlesHandler
 
                 if (last.Data.TotalPages == 0)
                 {
-                    return new ApiResponse<IReadOnlyList<ResponseData>>(final, response.StatusCode);
+                    return new ApiResponse<IReadOnlyList<ResponseData>>(final, response.Code);
                 }
 
                 if (max == -1)


### PR DESCRIPTION
Changes:
- If the request fails and the response body is empty `X-Reason` header will be used in error logs (if it exists)
- Replaced tuples with `HttpResponse` class
- If JSON parsing fails the status code and the context of the request will be logged (which search params were used or file id of the subtitle when downloading)
- Fixed pagination in `SearchSubtitlesAsync`
- Requests for subtitles in unsupported languages are now dropped and languages are now properly formatted (not yet, waiting for response from opensubtitles)

EDIT: also waiting for response regarding BadRequest during subtitle fetching

I messed something up when merging so now there's like 80 commits :weary: