### PR TITLE
Search improvements vol. 2 + minor fixes

### DIFF
--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
@@ -116,8 +116,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
             {
                 { "languages", language },
                 { "moviehash", hash },
-                { "type", request.ContentType == VideoContentType.Episode ? "episode" : "movie" },
-                { "query", request.ContentType == VideoContentType.Episode ? request.SeriesName : Path.GetFileName(request.MediaPath) }
+                { "type", request.ContentType == VideoContentType.Episode ? "episode" : "movie" }
             };
 
             // If we have the IMDb ID we use that, otherwise query with the details
@@ -127,10 +126,19 @@ namespace Jellyfin.Plugin.OpenSubtitles
             }
             else
             {
+                options.Add("query", Path.GetFileName(request.MediaPath));
+
                 if (request.ContentType == VideoContentType.Episode)
                 {
-                    options.Add("season_number", request.ParentIndexNumber?.ToString(_usCulture) ?? string.Empty);
-                    options.Add("episode_number", request.IndexNumber?.ToString(_usCulture) ?? string.Empty);
+                    if (request.ParentIndexNumber.HasValue)
+                    {
+                        options.Add("season_number", request.ParentIndexNumber.Value.ToString(_usCulture));
+                    }
+
+                    if (request.IndexNumber.HasValue)
+                    {
+                        options.Add("episode_number", request.IndexNumber.Value.ToString(_usCulture));
+                    }
                 }
             }
 

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
@@ -26,7 +26,6 @@ namespace Jellyfin.Plugin.OpenSubtitles
     /// </summary>
     public class OpenSubtitleDownloader : ISubtitleProvider
     {
-        private static readonly CultureInfo _usCulture = CultureInfo.ReadOnly(new CultureInfo("en-US"));
         private readonly ILogger<OpenSubtitleDownloader> _logger;
         private LoginInfo? _login;
         private DateTime? _limitReset;
@@ -81,7 +80,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
                 throw new AuthenticationException("API key not set up");
             }
 
-            long.TryParse(request.GetProviderId(MetadataProvider.Imdb)?.TrimStart('t') ?? string.Empty, NumberStyles.Any, _usCulture, out var imdbId);
+            long.TryParse(request.GetProviderId(MetadataProvider.Imdb)?.TrimStart('t') ?? string.Empty, NumberStyles.Any, CultureInfo.InvariantCulture, out var imdbId);
 
             if (request.ContentType == VideoContentType.Episode && (!request.IndexNumber.HasValue || !request.ParentIndexNumber.HasValue || string.IsNullOrEmpty(request.SeriesName)))
             {
@@ -122,7 +121,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
             // If we have the IMDb ID we use that, otherwise query with the details
             if (imdbId != 0)
             {
-                options.Add("imdb_id", imdbId.ToString(_usCulture));
+                options.Add("imdb_id", imdbId.ToString(CultureInfo.InvariantCulture));
             }
             else
             {
@@ -132,12 +131,12 @@ namespace Jellyfin.Plugin.OpenSubtitles
                 {
                     if (request.ParentIndexNumber.HasValue)
                     {
-                        options.Add("season_number", request.ParentIndexNumber.Value.ToString(_usCulture));
+                        options.Add("season_number", request.ParentIndexNumber.Value.ToString(CultureInfo.InvariantCulture));
                     }
 
                     if (request.IndexNumber.HasValue)
                     {
-                        options.Add("episode_number", request.IndexNumber.Value.ToString(_usCulture));
+                        options.Add("episode_number", request.IndexNumber.Value.ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -239,7 +238,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
             var language = idParts[1];
             var ossId = idParts[2];
 
-            var fid = int.Parse(ossId, _usCulture);
+            var fid = int.Parse(ossId, CultureInfo.InvariantCulture);
 
             var info = await OpenSubtitlesHandler.OpenSubtitles.GetSubtitleLinkAsync(fid, _login, _apiKey, cancellationToken).ConfigureAwait(false);
 

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
@@ -243,12 +243,9 @@ namespace Jellyfin.Plugin.OpenSubtitles
 
             var info = await OpenSubtitlesHandler.OpenSubtitles.GetSubtitleLinkAsync(fid, _login, _apiKey, cancellationToken).ConfigureAwait(false);
 
-            if (info.Data?.Message != null && info.Data.Message.Contains("UTC", StringComparison.Ordinal))
+            if (info.Data?.ResetTime != null)
             {
-                // "Your quota will be renewed in 20 hours and 52 minutes (2021-08-24 12:02:10 UTC) "
-                var str = info.Data.Message.Split('(')[1].Trim().Replace(" UTC)", "Z", StringComparison.Ordinal);
-                _limitReset = DateTime.Parse(str, _usCulture, DateTimeStyles.AdjustToUniversal);
-
+                _limitReset = info.Data.ResetTime;
                 _logger.LogDebug("Updated expiration time to {ResetTime}", _limitReset);
             }
 
@@ -295,7 +292,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
             {
                 var msg = string.Format(
                     CultureInfo.InvariantCulture,
-                    "Failed to obtain download link for file {0}: {1}",
+                    "Failed to obtain download link for file {0}: {1} (empty response)",
                     fid,
                     info.Code);
 

--- a/OpenSubtitlesHandler/Models/ApiResponse.cs
+++ b/OpenSubtitlesHandler/Models/ApiResponse.cs
@@ -82,6 +82,6 @@ namespace OpenSubtitlesHandler.Models
         /// <summary>
         /// Gets a value indicating whether the request was successful.
         /// </summary>
-        public bool Ok => (int)Code < 400;
+        public bool Ok => (int)Code >= 200 && (int)Code <= 299;
     }
 }

--- a/OpenSubtitlesHandler/Models/Responses/SubtitleDownloadInfo.cs
+++ b/OpenSubtitlesHandler/Models/Responses/SubtitleDownloadInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace OpenSubtitlesHandler.Models.Responses
 {
@@ -24,5 +25,11 @@ namespace OpenSubtitlesHandler.Models.Responses
         /// </summary>
         [JsonPropertyName("message")]
         public string? Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reset time.
+        /// </summary>
+        [JsonPropertyName("reset_time_utc")]
+        public DateTime? ResetTime { get; set; }
     }
 }

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -15,6 +15,8 @@ namespace OpenSubtitlesHandler
     /// </summary>
     public static class OpenSubtitles
     {
+        private static readonly CultureInfo _usCulture = CultureInfo.ReadOnly(new CultureInfo("en-US"));
+
         /// <summary>
         /// Login.
         /// </summary>
@@ -120,11 +122,6 @@ namespace OpenSubtitlesHandler
         {
             var opts = System.Web.HttpUtility.ParseQueryString(string.Empty);
 
-            foreach (var (key, value) in options.OrderBy(x => x.Key))
-            {
-                opts.Add(key, value);
-            }
-
             var max = -1;
             var current = 1;
 
@@ -134,11 +131,21 @@ namespace OpenSubtitlesHandler
 
             do
             {
-                opts.Set("page", current.ToString(CultureInfo.InvariantCulture));
+                opts.Clear();
+
+                if (current > 1)
+                {
+                    options["page"] = current.ToString(_usCulture);
+                }
+
+                foreach (var (key, value) in options.OrderBy(x => x.Key))
+                {
+                    opts.Add(key, value.ToLower(_usCulture));
+                }
 
                 response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);
 
-                last = new ApiResponse<SearchResult>(response, $"options: {options}", $"page: {current}");
+                last = new ApiResponse<SearchResult>(response, $"query: {opts}", $"page: {current}");
 
                 if (!last.Ok || last.Data == null)
                 {

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -15,8 +15,6 @@ namespace OpenSubtitlesHandler
     /// </summary>
     public static class OpenSubtitles
     {
-        private static readonly CultureInfo _usCulture = CultureInfo.ReadOnly(new CultureInfo("en-US"));
-
         /// <summary>
         /// Login.
         /// </summary>
@@ -135,12 +133,12 @@ namespace OpenSubtitlesHandler
 
                 if (current > 1)
                 {
-                    options["page"] = current.ToString(_usCulture);
+                    options["page"] = current.ToString(CultureInfo.InvariantCulture);
                 }
 
                 foreach (var (key, value) in options.OrderBy(x => x.Key))
                 {
-                    opts.Add(key.ToLower(_usCulture), value.ToLower(_usCulture));
+                    opts.Add(key.ToLower(CultureInfo.InvariantCulture), value.ToLower(CultureInfo.InvariantCulture));
                 }
 
                 response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);

--- a/OpenSubtitlesHandler/OpenSubtitles.cs
+++ b/OpenSubtitlesHandler/OpenSubtitles.cs
@@ -140,7 +140,7 @@ namespace OpenSubtitlesHandler
 
                 foreach (var (key, value) in options.OrderBy(x => x.Key))
                 {
-                    opts.Add(key, value.ToLower(_usCulture));
+                    opts.Add(key.ToLower(_usCulture), value.ToLower(_usCulture));
                 }
 
                 response = await RequestHandler.SendRequestAsync($"/subtitles?{opts}", HttpMethod.Get, null, null, apiKey, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Part 1/2 of changes suggested/requested by OpenSubtitles

Changes:
- Search params are all lowercase & properly sorted alphabetically
- Query is (again) provided only when imdb id is missing
- 3xx status codes are not considered valid anymore (fixes #73)
- [Weird string trickery](https://github.com/jellyfin/jellyfin-plugin-opensubtitles/commit/b8337449a5143684528de455fb498cd6d72e4ff6) is replaced by the new `reset_time_utc` property  


Closes #69