### PR TITLE
Implement default API key

### DIFF
--- a/Jellyfin.Plugin.OpenSubtitles/API/OpenSubtitlesController.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/API/OpenSubtitlesController.cs
@@ -38,7 +38,8 @@ namespace Jellyfin.Plugin.OpenSubtitles.API
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<ActionResult> ValidateLoginInfo([FromBody] LoginInfoInput body)
         {
-            var response = await OpenSubtitlesHandler.OpenSubtitles.LogInAsync(body.Username, body.Password, body.ApiKey, CancellationToken.None).ConfigureAwait(false);
+            var key = !string.IsNullOrWhiteSpace(body.ApiKey) ? body.ApiKey : OpenSubtitlesPlugin.ApiKey;
+            var response = await OpenSubtitlesHandler.OpenSubtitles.LogInAsync(body.Username, body.Password, key, CancellationToken.None).ConfigureAwait(false);
 
             if (!response.Ok)
             {
@@ -58,7 +59,7 @@ namespace Jellyfin.Plugin.OpenSubtitles.API
 
             if (response.Data != null)
             {
-                await OpenSubtitlesHandler.OpenSubtitles.LogOutAsync(response.Data, body.ApiKey, CancellationToken.None).ConfigureAwait(false);
+                await OpenSubtitlesHandler.OpenSubtitles.LogOutAsync(response.Data, key, CancellationToken.None).ConfigureAwait(false);
             }
 
             return Ok(new { Downloads = response.Data?.User?.AllowedDownloads ?? 0 });

--- a/Jellyfin.Plugin.OpenSubtitles/API/OpenSubtitlesController.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/API/OpenSubtitlesController.cs
@@ -38,7 +38,7 @@ namespace Jellyfin.Plugin.OpenSubtitles.API
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<ActionResult> ValidateLoginInfo([FromBody] LoginInfoInput body)
         {
-            var key = !string.IsNullOrWhiteSpace(body.ApiKey) ? body.ApiKey : OpenSubtitlesPlugin.ApiKey;
+            var key = !string.IsNullOrWhiteSpace(body.CustomApiKey) ? body.CustomApiKey : OpenSubtitlesPlugin.ApiKey;
             var response = await OpenSubtitlesHandler.OpenSubtitles.LogInAsync(body.Username, body.Password, key, CancellationToken.None).ConfigureAwait(false);
 
             if (!response.Ok)

--- a/Jellyfin.Plugin.OpenSubtitles/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/Configuration/PluginConfiguration.cs
@@ -18,8 +18,8 @@ namespace Jellyfin.Plugin.OpenSubtitles.Configuration
         public string Password { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the API Key.
+        /// Gets or sets the custom API Key.
         /// </summary>
-        public string ApiKey { get; set; } = string.Empty;
+        public string CustomApiKey { get; set; } = string.Empty;
     }
 }

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
@@ -85,7 +85,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
             {
                 throw new ArgumentNullException(nameof(request));
             }
-            
+
             long.TryParse(request.GetProviderId(MetadataProvider.Imdb)?.TrimStart('t') ?? string.Empty, NumberStyles.Any, CultureInfo.InvariantCulture, out var imdbId);
 
             if (request.ContentType == VideoContentType.Episode && (!request.IndexNumber.HasValue || !request.ParentIndexNumber.HasValue || string.IsNullOrEmpty(request.SeriesName)))

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitleDownloader.cs
@@ -57,7 +57,7 @@ namespace Jellyfin.Plugin.OpenSubtitles
         }
 
         /// <summary>
-        /// Gets the API key that will be used.
+        /// Gets the API key that will be used for requests.
         /// </summary>
         public string ApiKey
         {

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesPlugin.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesPlugin.cs
@@ -14,6 +14,11 @@ namespace Jellyfin.Plugin.OpenSubtitles
     public class OpenSubtitlesPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
         /// <summary>
+        /// Default API key to use when performing an API call.
+        /// </summary>
+        public const string ApiKey = "TBD";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OpenSubtitlesPlugin"/> class.
         /// </summary>
         /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>

--- a/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.html
+++ b/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.html
@@ -16,9 +16,9 @@
                     <div class="fieldDescription">You can utilize this plugin by editing a library and modifying the options for subtitle downloads.</div>
                 </div>
                 <div class="inputContainer">
-                    <input is="emby-input" type="password" id="apikey" label="${HeaderApiKey}:" />
+                    <input is="emby-input" type="password" id="apikey" label="(Optional) ${HeaderApiKey}:" />
                     <div class="fieldDescription">
-                        <a is="emby-linkbutton" class="button-link" target="_blank" href="https://www.opensubtitles.com/en/consumers/new">Create API Key</a>
+                        You can provide an <a is="emby-linkbutton" class="button-link" target="_blank" href="https://www.opensubtitles.com/en/consumers">API Key</a> for doing API requests, if left empty the default API key will be used.
                     </div>
                     <div class="fieldDescription">
                         <a is="emby-linkbutton" class="button-link" target="_blank" href="https://92500a62-df9e-42ed-82a4-e6b3eeb89365.site.hbuptime.com/">OpenSubtitles API Status</a>

--- a/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.js
+++ b/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.js
@@ -19,9 +19,9 @@ export default function (view, params) {
         Dashboard.showLoadingMsg();
         const form = this;
         ApiClient.getPluginConfiguration(OpenSubtitlesConfig.pluginUniqueId).then(function (config) {
-            const username = form.querySelector('#username').value;
-            const password = form.querySelector('#password').value;
-            const apiKey = form.querySelector('#apikey').value;
+            const username = form.querySelector('#username').value.trim();
+            const password = form.querySelector('#password').value.trim();
+            const apiKey = form.querySelector('#apikey').value.trim();
 
             if (!username || !password) {
                 Dashboard.processErrorResponse({statusText: "Account info is incomplete"});

--- a/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.js
+++ b/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.js
@@ -23,7 +23,7 @@ export default function (view, params) {
             const password = form.querySelector('#password').value;
             const apiKey = form.querySelector('#apikey').value;
 
-            if (!username || !password || !apiKey) {
+            if (!username || !password) {
                 Dashboard.processErrorResponse({statusText: "Account info is incomplete"});
                 return;
             }

--- a/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.js
+++ b/Jellyfin.Plugin.OpenSubtitles/Web/opensubtitles.js
@@ -9,7 +9,7 @@ export default function (view, params) {
         ApiClient.getPluginConfiguration(OpenSubtitlesConfig.pluginUniqueId).then(function (config) {
             page.querySelector('#username').value = config.Username || '';
             page.querySelector('#password').value = config.Password || '';
-            page.querySelector('#apikey').value = config.ApiKey || '';
+            page.querySelector('#apikey').value = config.CustomApiKey || '';
             Dashboard.hideLoadingMsg();
         });
     });
@@ -30,7 +30,7 @@ export default function (view, params) {
 
             const el = form.querySelector('#ossresponse');
             
-            const data = JSON.stringify({ Username: username, Password: password, ApiKey: apiKey });
+            const data = JSON.stringify({ Username: username, Password: password, CustomApiKey: apiKey });
             const url = ApiClient.getUrl('Jellyfin.Plugin.OpenSubtitles/ValidateLoginInfo');
 
             const handler = response => response.json().then(res => {
@@ -39,7 +39,7 @@ export default function (view, params) {
 
                     config.Username = username;
                     config.Password = password;
-                    config.ApiKey = apiKey;
+                    config.CustomApiKey = apiKey;
 
                     ApiClient.updatePluginConfiguration(OpenSubtitlesConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);

--- a/OpenSubtitlesHandler/Models/LoginInfoInput.cs
+++ b/OpenSubtitlesHandler/Models/LoginInfoInput.cs
@@ -22,7 +22,6 @@ namespace OpenSubtitlesHandler.Models
         /// <summary>
         /// Gets or sets the api key.
         /// </summary>
-        [Required]
         public string ApiKey { get; set; } = null!;
     }
 }

--- a/OpenSubtitlesHandler/Models/LoginInfoInput.cs
+++ b/OpenSubtitlesHandler/Models/LoginInfoInput.cs
@@ -20,8 +20,8 @@ namespace OpenSubtitlesHandler.Models
         public string Password { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets the api key.
+        /// Gets or sets the custom api key.
         /// </summary>
-        public string ApiKey { get; set; } = null!;
+        public string CustomApiKey { get; set; } = null!;
     }
 }


### PR DESCRIPTION
Part 2/2 of changes suggested/requested by OpenSubtitles

Adds the default API key which the plugin uses if the user hasn't provided their own

Closes #70

draft until the official jellyfin API key is provided