### PR TITLE
fix possible parsing problem

### DIFF
--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/RequestHandler.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/RequestHandler.cs
@@ -47,7 +47,8 @@ public static class RequestHandler
         if (response.statusCode == HttpStatusCode.TooManyRequests
             && attempt < RetryLimit
             && response.headers.TryGetValue(HeaderNames.RetryAfter, out var retryAfterStr)
-            && int.TryParse(retryAfterStr, out var retryAfter))
+            && int.TryParse(retryAfterStr, out var retryAfter)
+            && retryAfter >=0)
         {
             await Task.Delay(TimeSpan.FromSeconds(retryAfter), cancellationToken).ConfigureAwait(false);
             return await SendRequestAsync(endpoint, method, body, headers, attempt + 1, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
to possibly fix this:

```
[2025-11-20 14:21:16.030 +13:00] [ERR] [170] MediaBrowser.Providers.Subtitles.SubtitleManager: Error downloading subtitles from "Open Subtitles"
System.ArgumentOutOfRangeException: The value needs to be either -1 (signifying an infinite timeout), 0 or a positive integer. (Parameter 'millisecondsDelay')
   at Jellyfin.Plugin.OpenSubtitles.OpenSubtitlesHandler.RequestHandler.SendRequestAsync(String endpoint, HttpMethod method, Object body, Dictionary`2 headers, Int32 attempt, CancellationToken cancellationToken)
   at Jellyfin.Plugin.OpenSubtitles.OpenSubtitlesHandler.OpenSubtitlesApi.LogInAsync(String username, String password, CancellationToken cancellationToken)
   at Jellyfin.Plugin.OpenSubtitles.OpenSubtitleDownloader.Login(CancellationToken cancellationToken)
   at Jellyfin.Plugin.OpenSubtitles.OpenSubtitleDownloader.Search(SubtitleSearchRequest request, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Subtitles.SubtitleManager.SearchSubtitles(SubtitleSearchRequest request, CancellationToken cancellationToken)
```