### PR TITLE
Fix 429 handling

### DIFF
--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/OpenSubtitlesApi.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/OpenSubtitlesApi.cs
@@ -95,18 +95,14 @@ public static class OpenSubtitlesApi
     /// <returns>The Http response.</returns>
     public static async Task<HttpResponse> DownloadSubtitleAsync(string url, CancellationToken cancellationToken)
     {
-        var response = await OpenSubtitlesRequestHelper.Instance!.SendRequestAsync(
+        return await RequestHandler.SendRequestAsync(
             url,
             HttpMethod.Get,
             null,
-            new Dictionary<string, string>(),
-            cancellationToken).ConfigureAwait(false);
-
-        return new HttpResponse
-        {
-            Body = response.body,
-            Code = response.statusCode
-        };
+            [],
+            1,
+            cancellationToken,
+            true).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/RequestHandler.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/RequestHandler.cs
@@ -53,13 +53,13 @@ public static class RequestHandler
             && int.TryParse(retryAfterStr, out var retryAfter))
         {
             await Task.Delay(TimeSpan.FromSeconds(retryAfter), cancellationToken).ConfigureAwait(false);
-            return await SendRequestAsync(endpoint, method, body, headers, attempt + 1, cancellationToken).ConfigureAwait(false);
+            return await SendRequestAsync(endpoint, method, body, headers, attempt + 1, cancellationToken, isFullUrl).ConfigureAwait(false);
         }
 
         if (response.statusCode == HttpStatusCode.BadGateway && attempt < RetryLimit)
         {
             await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
-            return await SendRequestAsync(endpoint, method, body, headers, attempt + 1, cancellationToken).ConfigureAwait(false);
+            return await SendRequestAsync(endpoint, method, body, headers, attempt + 1, cancellationToken, isFullUrl).ConfigureAwait(false);
         }
 
         if (!response.headers.TryGetValue("x-reason", out var responseReason))

--- a/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/RequestHandler.cs
+++ b/Jellyfin.Plugin.OpenSubtitles/OpenSubtitlesHandler/RequestHandler.cs
@@ -29,6 +29,7 @@ public static class RequestHandler
     /// <param name="headers">The headers.</param>
     /// <param name="attempt">The request attempt key.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="isFullUrl">The flag to not append baseUrl.</param>
     /// <returns>The response.</returns>
     /// <exception cref="ArgumentException">API Key is empty.</exception>
     public static async Task<HttpResponse> SendRequestAsync(
@@ -37,12 +38,14 @@ public static class RequestHandler
         object? body,
         Dictionary<string, string>? headers,
         int attempt,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool isFullUrl = false)
     {
         headers ??= new Dictionary<string, string>();
         headers.TryAdd("Api-Key", OpenSubtitlesPlugin.ApiKey);
 
-        var response = await OpenSubtitlesRequestHelper.Instance!.SendRequestAsync(BaseApiUrl + endpoint, method, body, headers, cancellationToken).ConfigureAwait(false);
+        var url = isFullUrl ? endpoint : BaseApiUrl + endpoint;
+        var response = await OpenSubtitlesRequestHelper.Instance!.SendRequestAsync(url, method, body, headers, cancellationToken).ConfigureAwait(false);
 
         if (response.statusCode == HttpStatusCode.TooManyRequests
             && attempt < RetryLimit


### PR DESCRIPTION
DownloadSubtitleAsync was not using RequestHandler so when ClientSideRateLimitedHandler kicked in the download failed with TooManyRequests

also improved logging 

Fixes confusing logs in https://github.com/jellyfin/jellyfin-plugin-opensubtitles/issues/185 but doesn't solve the issue, needs server changes